### PR TITLE
added catching of php7 fatal exceptions in application #20110

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -123,25 +123,9 @@ class Application
         try {
             $exitCode = $this->doRun($input, $output);
         } catch (\Exception $e) {
-            if (!$this->catchExceptions) {
-                throw $e;
-            }
-
-            if ($output instanceof ConsoleOutputInterface) {
-                $this->renderException($e, $output->getErrorOutput());
-            } else {
-                $this->renderException($e, $output);
-            }
-
-            $exitCode = $e->getCode();
-            if (is_numeric($exitCode)) {
-                $exitCode = (int) $exitCode;
-                if (0 === $exitCode) {
-                    $exitCode = 1;
-                }
-            } else {
-                $exitCode = 1;
-            }
+            $exitCode = $this->handleCommandRunException($e, $output);
+        } catch (\Throwable $e) {
+            $exitCode = $this->handleCommandRunException($e, $output);
         }
 
         if ($this->autoExit) {
@@ -150,6 +134,39 @@ class Application
             }
 
             exit($exitCode);
+        }
+
+        return $exitCode;
+    }
+
+    /**
+     * Handler command run exception and provides with the exit code in return
+     *
+     * @param \Exception|\Throwable $e
+     * @param OutputInterface $output
+     * @return int|mixed
+     * @throws \Throwable
+     */
+    private function handleCommandRunException($e, OutputInterface $output)
+    {
+        if (!$this->catchExceptions) {
+            throw $e;
+        }
+
+        if ($output instanceof ConsoleOutputInterface) {
+            $this->renderException($e, $output->getErrorOutput());
+        } else {
+            $this->renderException($e, $output);
+        }
+
+        $exitCode = $e->getCode();
+        if (is_numeric($exitCode)) {
+            $exitCode = (int) $exitCode;
+            if (0 === $exitCode) {
+                $exitCode = 1;
+            }
+        } else {
+            $exitCode = 1;
         }
 
         return $exitCode;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / 2.7, 2.8 or 3.1 for fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

- added new private method to application, which would process the exception and return the exit code / throw it
- added another catch into command run method, which would ensure that under PHP7 all exceptions are being catched as well